### PR TITLE
Fix widget not working when third-party tracking is disabled

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -4,18 +4,38 @@ interface Location {
   search: string;
 }
 
+const tryLocalStorageAccess = <R>(f: () => R): R | null => {
+  try {
+    return f();
+  } catch (e) {
+    if (e instanceof DOMException) {
+      // localStorage access is disallowed, or it is full.
+      return null;
+    }
+    throw e;
+  }
+};
+
+const getLocalStorageItem = (key: string): string | null => {
+  return tryLocalStorageAccess(() => window.localStorage.getItem(key));
+};
+
+const setLocalStorageItem = (key: string, value: string) => {
+  tryLocalStorageAccess(() => window.localStorage.setItem(key, value));
+};
+
 export const getTheme = (location: Location = window.location) => {
   const urlParams = new URLSearchParams(location.search);
   const theme = urlParams.get('theme');
   const widgetId = urlParams.get('widgetId') || '';
-  const currentTheme = theme || window.localStorage.getItem(`${widgetId}_theme`) || DEFAULT_THEME;
-  window.localStorage.setItem(`${widgetId}_theme`, currentTheme);
+  const currentTheme = theme || getLocalStorageItem(`${widgetId}_theme`) || DEFAULT_THEME;
+  setLocalStorageItem(`${widgetId}_theme`, currentTheme);
   return currentTheme;
 };
 export const switchTheme = (location: Location = window.location) => {
   const urlParams = new URLSearchParams(location.search);
   const widgetId = urlParams.get('widgetId') || '';
-  const theme = urlParams.get('theme') || window.localStorage.getItem(`${widgetId}_theme`) || DEFAULT_THEME;
+  const theme = urlParams.get('theme') || getLocalStorageItem(`${widgetId}_theme`) || DEFAULT_THEME;
   if (theme === 'light') {
     urlParams.set('theme', 'dark');
   } else {


### PR DESCRIPTION
When third-party cookies are disabled in Chrome, use of `localStorage`
raises a `DOMException`. Handle the exception so that the widget
can work in this browser configuration.

Resolves #2.