### PR TITLE
Update the schedule widget at midnight (Brussels time)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import styled from 'styled-components';
 import LoginPage from './components/account/LoginPage';
 import LoginProvider from './components/common/LoginProvider';
 import SchedulePanel from './components/schedule/SchedulePanel';
+import { updateTodayLoop } from './reducer/schedulesSlice';
 
 const Container = styled.div`
   text-align: center;
@@ -19,6 +21,12 @@ const Container = styled.div`
 `;
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(updateTodayLoop);
+  });
+
   return (
     <Container>
       <LoginProvider>

--- a/src/reducer/schedulesSlice.ts
+++ b/src/reducer/schedulesSlice.ts
@@ -180,7 +180,7 @@ export async function updateTodayLoop(dispatch: any): Promise<void> {
 
     // Sleep.
     console.log('Waiting for new day in ', timeToWaitMilliseconds / 1000);
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       window.setTimeout(resolve, timeToWaitMilliseconds);
     });
     console.log('New day, refreshing');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
I have tested this by setting my system clock to FOSDEM 2023.
At 23h00m30s (UK time), the schedule refreshed with the new schedule.

The 30s gap is to ensure we are definitely over into the next day, so we don't spin away as we get ever closer to the end of the day.