### PR TITLE
Update the schedule URL to point to FOSDEM 2026

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ const apiProxy = createProxyMiddleware('/schedule', {
   pathRewrite: {
     '^/schedule': ''
   },
-  target: 'https://fosdem.org/2025/schedule/xml'
+  target: 'https://fosdem.org/2026/schedule/xml'
 });
 app.use('/schedule', apiProxy);
 

--- a/src/components/schedule/EventView.tsx
+++ b/src/components/schedule/EventView.tsx
@@ -20,7 +20,7 @@ const EventView = ({ event }: IEventViewProps) => {
   const [url, setUrl] = useState<string | undefined>();
 
   useEffect(() => {
-    setUrl(`https://fosdem.org/2025/schedule/event/${event.slug}`);
+    setUrl(`https://fosdem.org/2026/schedule/event/${event.slug}`);
   }, [event]);
 
   const openEvent = useCallback(() => {

--- a/src/reducer/schedulesSlice.ts
+++ b/src/reducer/schedulesSlice.ts
@@ -126,7 +126,7 @@ export const getScheduleAsync = debounceAction((roomName: string): AppThunk => {
   return async (dispatch: any) => {
     dispatch(scheduleSlice.actions.setIsLoading(true));
     try {
-      const response = await fetch((process.env.NODE_ENV === 'development') ? 'https://fosdem.org/2025/schedule/xml' : '/schedule');
+      const response = await fetch((process.env.NODE_ENV === 'development') ? 'https://fosdem.org/2026/schedule/xml' : '/schedule');
       if (response.ok) {
         const xmlStr = await response.text();
         const parser = new DOMParser();


### PR DESCRIPTION
The equivalent of https://github.com/matrix-org/fosdem-schedule-element-widget/pull/12, but for 2026.

Might be nice to make this a config option in the future.